### PR TITLE
Fix load static linux binary

### DIFF
--- a/src/engines/native_posix.inc
+++ b/src/engines/native_posix.inc
@@ -7,7 +7,7 @@ uint64_t TargetMemory::mmap(uint64_t addr, size_t size) {
                      PROT_READ | PROT_WRITE | PROT_EXEC,
                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 
-  if (ret == nullptr) {
+  if (ret == MAP_FAILED) {
     Logger::err("Error while trying mmap: {}", strerror(errno));
     return 0;
   }

--- a/src/loaders/ELF.cpp
+++ b/src/loaders/ELF.cpp
@@ -108,7 +108,7 @@ void ELF::load(BIND binding) {
   Binary &binary = get_binary();
 
   uint64_t virtual_size = binary.virtual_size();
-  virtual_size -= binary.imagebase();
+  virtual_size -= page_offset(binary.imagebase());
   virtual_size = page_align(virtual_size);
   mem_size_ = virtual_size;
 

--- a/src/logging.hpp
+++ b/src/logging.hpp
@@ -4,7 +4,7 @@
 #include "spdlog/spdlog.h"
 #include <QBDL/log.hpp>
 
-#ifndef NDEBUG
+#ifdef NDEBUG
 static constexpr bool QBDL_DEBUG_ENABLED = false;
 #else
 static constexpr bool QBDL_DEBUG_ENABLED = true;


### PR DESCRIPTION
The load of static ELF binary generate a segmentation fault. This PR should fix this issue.