### PR TITLE
Implement X86_R64 reloc and fix others

### DIFF
--- a/src/loaders/ELF.cpp
+++ b/src/loaders/ELF.cpp
@@ -214,20 +214,22 @@ void ELF::reloc_x86_64(const LIEF::ELF::Relocation &reloc) {
   const auto type = static_cast<RELOC_x86_64>(reloc.type());
   const uintptr_t addr_target = base_address_ + reloc.address();
   switch (type) {
+  case RELOC_x86_64::R_X86_64_64: {
+    const uintptr_t sym_addr = resolve_or_symlink(reloc.symbol());
+    engine_->mem().write_ptr(binarch, addr_target, sym_addr + reloc.addend());
+    break;
+  }
+
   case RELOC_x86_64::R_X86_64_RELATIVE: {
     engine_->mem().write_ptr(binarch, addr_target,
                              base_address_ + reloc.addend());
     break;
   }
 
+  case RELOC_x86_64::R_X86_64_GLOB_DAT:
   case RELOC_x86_64::R_X86_64_JUMP_SLOT: {
     const uintptr_t sym_addr = resolve_or_symlink(reloc.symbol());
-    engine_->mem().write_ptr(binarch, addr_target, sym_addr + reloc.addend());
-    break;
-  }
-  case RELOC_x86_64::R_X86_64_GLOB_DAT: {
-    const uintptr_t sym_addr = resolve_or_symlink(reloc.symbol());
-    engine_->mem().write_ptr(binarch, addr_target, sym_addr + reloc.addend());
+    engine_->mem().write_ptr(binarch, addr_target, sym_addr);
     break;
   }
 


### PR DESCRIPTION
According to https://docs.oracle.com/cd/E19120-01/open.solaris/819-0690/chapter7-2/index.html `R_X86_64_GLOB_DAT` and `R_X86_64_JUMP_SLOT` should simply return the symbol address, and I also implemented `R_X86_64_64`.